### PR TITLE
Adds /silences command

### DIFF
--- a/alerticular/alertmanager.py
+++ b/alerticular/alertmanager.py
@@ -1,0 +1,17 @@
+import json
+from typing import List, Dict
+
+import aiohttp
+
+ALERTMANAGER_BASE_URL = "http://localhost:33691"
+
+
+async def get_alerts() -> List[Dict]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{ALERTMANAGER_BASE_URL}/api/v1/alerts") as response:
+            response.raise_for_status()
+            response_text = await response.text()
+            response_json = json.loads(response_text)
+            if response_json["status"] != "success":
+                raise AssertionError(f"Request failed: {response_json['status']}")
+            return response_json["data"]

--- a/alerticular/alertmanager.py
+++ b/alerticular/alertmanager.py
@@ -1,4 +1,5 @@
 import json
+from datetime import datetime
 from typing import List, Dict
 
 import aiohttp
@@ -8,10 +9,56 @@ ALERTMANAGER_BASE_URL = "http://localhost:33691"
 
 async def get_alerts() -> List[Dict]:
     async with aiohttp.ClientSession() as session:
-        async with session.get(f"{ALERTMANAGER_BASE_URL}/api/v1/alerts") as response:
+        async with session.get(f"{ALERTMANAGER_BASE_URL}/api/v2/alerts") as response:
+            response.raise_for_status()
+            response_text = await response.text()
+            return json.loads(response_text)
+
+
+async def get_silences() -> List[Dict]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{ALERTMANAGER_BASE_URL}/api/v2/silences") as response:
+            response.raise_for_status()
+            response_text = await response.text()
+            return json.loads(response_text)
+
+
+async def silence(matchers: List[Dict],
+                  starts_at: datetime,
+                  ends_at: datetime,
+                  created_by: str,
+                  silence_id: str = None,
+                  comment: str = "", ) -> str:
+    """
+    Creates or updates a silence.
+
+    Specify matchers as dict elements of the following format:
+    {
+        "name": "string",
+        "value": "string",
+        "isRegex": True
+    }
+
+    :param matchers: list of alert matchers
+    :param starts_at: start time of the silence
+    :param ends_at: end time of the silence
+    :param created_by: user that created this silence
+    :param silence_id: ID of the existing silence (if any)
+    :param comment: comment for this silence
+    :return: ID of the created/updated silence
+    """
+    request_data = {
+        "id": silence_id,
+        "matchers": matchers,
+        "startsAt": starts_at.isoformat(),
+        "endsAt": ends_at.isoformat(),
+        "createdBy": created_by,
+        "comment": comment
+    }
+
+    async with aiohttp.ClientSession() as session:
+        async with session.post(f"{ALERTMANAGER_BASE_URL}/api/v2/silences", data=request_data) as response:
             response.raise_for_status()
             response_text = await response.text()
             response_json = json.loads(response_text)
-            if response_json["status"] != "success":
-                raise AssertionError(f"Request failed: {response_json['status']}")
-            return response_json["data"]
+            return response_json["silenceID"]

--- a/alerticular/telegram.py
+++ b/alerticular/telegram.py
@@ -1,9 +1,12 @@
 import logging
 from typing import Any, Dict
 
-from aiogram import Bot, Dispatcher, executor, types
+from aiogram import Bot, Dispatcher, types
 from aiogram.utils.emoji import emojize
 from jinja2 import Environment, PackageLoader
+from telegram_click_aio.decorator import command
+
+from alerticular import alertmanager
 
 logger = logging.getLogger(__name__)
 JSONType = Dict[str, Any]
@@ -23,6 +26,7 @@ def setup(token: str) -> None:
     bot = Bot(token=token)
     dispatcher = Dispatcher(bot)
     dispatcher.register_message_handler(send_welcome, commands=["start", "help"])
+    dispatcher.register_message_handler(handle_alerts, commands=["alerts", "a"])
     dispatcher.register_message_handler(echo)
 
 
@@ -36,6 +40,22 @@ async def send_welcome(message: types.Message) -> None:
     await message.reply(
         "This bot is alerticular good!\nYour chat ID is: `{}`".format(message.chat.id), parse_mode="Markdown"
     )
+
+
+@command(name=["alerts", "a"], description='Show a list of all alerts.')
+async def handle_alerts(message: types.Message) -> None:
+    logger.info("{}: {}".format(message.chat, message.text))
+    alerts = await alertmanager.get_alerts()
+    lines = []
+    for alert in alerts:
+        alert_name = alert.get("labels", {}).get("alertname", None)
+        alert_message = alert.get("annotations", {}).get("message", None)
+        if alert_name is not None:
+            lines.append(f":fire: {alert_name}: {alert_message}")
+    text = "\n".join(lines).strip()
+    if len(text) <= 0:
+        text = "No alerts right now"
+    await message.reply(emojize(text), parse_mode="Markdown", disable_web_page_preview=True)
 
 
 async def echo(message: types.Message) -> None:

--- a/alerticular/telegram.py
+++ b/alerticular/telegram.py
@@ -27,6 +27,7 @@ def setup(token: str) -> None:
     dispatcher = Dispatcher(bot)
     dispatcher.register_message_handler(send_welcome, commands=["start", "help"])
     dispatcher.register_message_handler(handle_alerts, commands=["alerts", "a"])
+    dispatcher.register_message_handler(handle_silences, commands=["silences", "s"])
     dispatcher.register_message_handler(echo)
 
 
@@ -55,6 +56,17 @@ async def handle_alerts(message: types.Message) -> None:
     text = "\n".join(lines).strip()
     if len(text) <= 0:
         text = "No alerts right now"
+    await message.reply(emojize(text), parse_mode="Markdown", disable_web_page_preview=True)
+
+
+@command(name=["silences", "s"], description='Show a list of all silences.')
+async def handle_silences(message: types.Message) -> None:
+    logger.info("{}: {}".format(message.chat, message.text))
+    silences = await alertmanager.get_silences()
+    texts = list(map(str, silences))
+    text = "\n".join(texts).strip()
+    if len(text) <= 0:
+        text = "No silences right now"
     await message.reply(emojize(text), parse_mode="Markdown", disable_web_page_preview=True)
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ click
 emoji
 Jinja2
 prometheus_async[aiohttp]
+telegram-click-aio


### PR DESCRIPTION
This PR is based on the `alerts_command` branch and is therefore supposed to be merged into that branch. Not sure if there is a better way to deal with this, let me know.

Adds a `/silences` (or `/s`) command to the telegram bot to retrieve a list of all silences in alertmanager.
Similar to #3, this is currently a rough implementation, only printing the raw json blobs.

This PR also contains code to create/update silences in alertmanager. It is currently not used anywhere, since I was unsure what the best way to automate the creation of silences would be. Create a matcher might not be trivial if alerts are grouped, so adding a "Silence for a day" button might not be that practical. Instead, it might be necessary to use a dedicated `/silence` command, but that would require the user to specify a matcher in telegram, which also doesn't sound like a great UX... thoughts welcome.

I just had a look at how alertmanager does this itself, and this is the URL that is used for silencing the watchdog alert:
```
http://localhost:33691/#/silences/new?filter=%7Balertname%3D%22Watchdog%22%2C%20prometheus%3D%22prometheus%2Fprometheus-kube-prometheus-prometheus%22%2C%20severity%3D%22none%22%7D
```
Which seems to be pretty specific. Looking at their code they have multiple functions to create a silence from an alert:

https://github.com/prometheus/alertmanager/blob/00b86d90674fb060670edeecbc2e7e85bf64ab51/ui/app/src/Views/SilenceForm/Parsing.elm#L11

I think the one we should use is the one using an  "equal" matcher for all labels on the alert.