### PR TITLE
Add /alerts command

### DIFF
--- a/alerticular/alertmanager.py
+++ b/alerticular/alertmanager.py
@@ -1,0 +1,17 @@
+import json
+from typing import List, Dict
+
+import aiohttp
+
+ALERTMANAGER_BASE_URL = "http://localhost:33691"
+
+
+async def get_alerts() -> List[Dict]:
+    async with aiohttp.ClientSession() as session:
+        async with session.get(f"{ALERTMANAGER_BASE_URL}/api/v1/alerts") as response:
+            response.raise_for_status()
+            response_text = await response.text()
+            response_json = json.loads(response_text)
+            if response_json["status"] != "success":
+                raise AssertionError(f"Request failed: {response_json['status']}")
+            return response_json["data"]

--- a/alerticular/telegram.py
+++ b/alerticular/telegram.py
@@ -4,6 +4,9 @@ from typing import Any, Dict
 from aiogram import Bot, Dispatcher, types
 from aiogram.utils.emoji import emojize
 from jinja2 import Environment, PackageLoader
+from telegram_click_aio.decorator import command
+
+from alerticular import alertmanager
 
 logger = logging.getLogger(__name__)
 JSONType = Dict[str, Any]
@@ -23,6 +26,7 @@ def setup(token: str) -> None:
     bot = Bot(token=token)
     dispatcher = Dispatcher(bot)
     dispatcher.register_message_handler(send_welcome, commands=["start", "help"])
+    dispatcher.register_message_handler(handle_alerts, commands=["alerts", "a"])
     dispatcher.register_message_handler(echo)
 
 
@@ -36,6 +40,22 @@ async def send_welcome(message: types.Message) -> None:
     await message.reply(
         "This bot is alerticular good!\nYour chat ID is: `{}`".format(message.chat.id), parse_mode="Markdown"
     )
+
+
+@command(name=["alerts", "a"], description='Show a list of all alerts.')
+async def handle_alerts(message: types.Message) -> None:
+    logger.info("{}: {}".format(message.chat, message.text))
+    alerts = await alertmanager.get_alerts()
+    lines = []
+    for alert in alerts:
+        alert_name = alert.get("labels", {}).get("alertname", None)
+        alert_message = alert.get("annotations", {}).get("message", None)
+        if alert_name is not None:
+            lines.append(f":fire: {alert_name}: {alert_message}")
+    text = "\n".join(lines).strip()
+    if len(text) <= 0:
+        text = "No alerts right now"
+    await message.reply(emojize(text), parse_mode="Markdown", disable_web_page_preview=True)
 
 
 async def echo(message: types.Message) -> None:

--- a/alerticular/telegram.py
+++ b/alerticular/telegram.py
@@ -42,7 +42,7 @@ async def send_welcome(message: types.Message) -> None:
     )
 
 
-@command(name=["alerts", "a"], description='Show a list of all alerts.')
+@command(name=["alerts", "a"], description="Show a list of all alerts.")
 async def handle_alerts(message: types.Message) -> None:
     logger.info("{}: {}".format(message.chat, message.text))
     alerts = await alertmanager.get_alerts()

--- a/poetry.lock
+++ b/poetry.lock
@@ -154,7 +154,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "emoji"
-version = "1.1.0"
+version = "1.2.0"
 description = "Emoji for Python"
 category = "main"
 optional = false
@@ -214,19 +214,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "pendulum"
-version = "1.5.1"
-description = "Python datetimes made easy."
-category = "main"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-
-[package.dependencies]
-python-dateutil = ">=2.6.0.0,<3.0.0.0"
-pytzdata = ">=2018.3.0.0"
-tzlocal = ">=1.5.0.0,<2.0.0.0"
-
-[[package]]
 name = "prometheus-async"
 version = "19.2.0"
 description = "Async helpers for prometheus_client."
@@ -284,17 +271,6 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
-name = "python-dateutil"
-version = "2.8.1"
-description = "Extensions to the standard Python datetime module"
-category = "main"
-optional = true
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,>=2.7"
-
-[package.dependencies]
-six = ">=1.5"
-
-[[package]]
 name = "pytz"
 version = "2020.5"
 description = "World timezone definitions, modern and historical"
@@ -303,20 +279,27 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pytzdata"
-version = "2020.1"
-description = "The Olson timezone database for Python."
+name = "telegram-click-aio"
+version = "1.0.0"
+description = "Click inspired command interface toolkit for aiogram"
 category = "main"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+optional = false
+python-versions = "*"
 
-[[package]]
-name = "six"
-version = "1.15.0"
-description = "Python 2 and 3 compatibility utilities"
-category = "main"
-optional = true
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
+[package.dependencies]
+aiogram = "*"
+aiohttp = "*"
+async-timeout = "*"
+attrs = "*"
+babel = "*"
+certifi = "*"
+chardet = "*"
+emoji = "*"
+idna = "*"
+multidict = "*"
+pytz = "*"
+typing-extensions = "*"
+yarl = "*"
 
 [[package]]
 name = "typing"
@@ -334,17 +317,6 @@ description = "Backported and Experimental Type Hints for Python 3.5+"
 category = "main"
 optional = false
 python-versions = "*"
-
-[[package]]
-name = "tzlocal"
-version = "1.5.1"
-description = "tzinfo object for the local timezone"
-category = "main"
-optional = true
-python-versions = "*"
-
-[package.dependencies]
-pytz = "*"
 
 [[package]]
 name = "wrapt"
@@ -373,7 +345,7 @@ python = "<3.8"
 [metadata]
 lock-version = "1.0"
 python-versions = "^3.6"  # Compatible python versions must be declared here
-content-hash = "cd37197ea615cac4e73a23ca937622d69c1e1fa9c8c406665bbfc3994a3d8e60"
+content-hash = "5b5c5af4480d6ddac6886367695afaa6648eb8414cf974d62366cc3e1bd85d1c"
 
 [metadata.files]
 aiodns = [
@@ -556,8 +528,8 @@ click = [
     {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 emoji = [
-    {file = "emoji-1.1.0-py3-none-any.whl", hash = "sha256:153fbf06eb5a111ca2b0c04f6f14ec3be434946a302f7892bf4c30446e050381"},
-    {file = "emoji-1.1.0.tar.gz", hash = "sha256:87c934907deb25e9621b0c48cac2051ad932636ad5946c4de6ba0f5f45a61fcd"},
+    {file = "emoji-1.2.0-py3-none-any.whl", hash = "sha256:6b19b65da8d6f30551eead1705539cc0eadcd9e33a6ecbc421a29b87f96287eb"},
+    {file = "emoji-1.2.0.tar.gz", hash = "sha256:496f432058567985838c13d67dde84ca081614a8286c0b9cdc7d63dfa89d51a3"},
 ]
 idna = [
     {file = "idna-3.1-py3-none-any.whl", hash = "sha256:5205d03e7bcbb919cc9c19885f9920d622ca52448306f2377daede5cf3faac16"},
@@ -644,18 +616,6 @@ multidict = [
     {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
     {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
 ]
-pendulum = [
-    {file = "pendulum-1.5.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:ddaf97a061eb5e2ae37857a8cb548e074125017855690d20e443ad8d9f31e164"},
-    {file = "pendulum-1.5.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c04fcf955e622e97e405e5f6d1b1f4a7adc69d79d82f3609643de69283170d6d"},
-    {file = "pendulum-1.5.1-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:dd6500d27bb7ccc029d497da4f9bd09549bd3c0ea276dad894ea2fdf309e83f3"},
-    {file = "pendulum-1.5.1-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:95536b33ae152e3c831eb236c1bf9ac9dcfb3b5b98fdbe8e9e601eab6c373897"},
-    {file = "pendulum-1.5.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:f4eee1e1735487d9d25cc435c519fd4380cb1f82cde3ebad1efbc2fc30deca5b"},
-    {file = "pendulum-1.5.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:4173ce3e81ad0d9d61dbce86f4286c43a26a398270df6a0a89f501f0c28ad27d"},
-    {file = "pendulum-1.5.1-cp36-cp36m-macosx_10_13_x86_64.whl", hash = "sha256:e9732b8bb214fad2c72ddcbfec07542effa8a8b704e174347ede1ff8dc679cce"},
-    {file = "pendulum-1.5.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:56a347d0457859c84b8cdba161fc37c7df5db9b3becec7881cd770e9d2058b3c"},
-    {file = "pendulum-1.5.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e7df37447824f9af0b58c7915a4caf349926036afd86ad38e7529a6b2f8fc34b"},
-    {file = "pendulum-1.5.1.tar.gz", hash = "sha256:738878168eb26e5446da5d1f7b3312ae993a542061be8882099c00ef4866b1a2"},
-]
 prometheus-async = [
     {file = "prometheus_async-19.2.0-py2.py3-none-any.whl", hash = "sha256:227f516e5bf98a0dc602348381e182358f8b2ed24a8db05e8e34d9cf027bab83"},
     {file = "prometheus_async-19.2.0.tar.gz", hash = "sha256:3cc68d1f39e9bbf16dbd0b51103d87671b3cbd1d75a72cda472cd9a35cc9d0d2"},
@@ -699,21 +659,13 @@ pycparser = [
     {file = "pycparser-2.20-py2.py3-none-any.whl", hash = "sha256:7582ad22678f0fcd81102833f60ef8d0e57288b6b5fb00323d101be910e35705"},
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
-python-dateutil = [
-    {file = "python-dateutil-2.8.1.tar.gz", hash = "sha256:73ebfe9dbf22e832286dafa60473e4cd239f8592f699aa5adaf10050e6e1823c"},
-    {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
-]
 pytz = [
     {file = "pytz-2020.5-py2.py3-none-any.whl", hash = "sha256:16962c5fb8db4a8f63a26646d8886e9d769b6c511543557bc84e9569fb9a9cb4"},
     {file = "pytz-2020.5.tar.gz", hash = "sha256:180befebb1927b16f6b57101720075a984c019ac16b1b7575673bea42c6c3da5"},
 ]
-pytzdata = [
-    {file = "pytzdata-2020.1-py2.py3-none-any.whl", hash = "sha256:e1e14750bcf95016381e4d472bad004eef710f2d6417240904070b3d6654485f"},
-    {file = "pytzdata-2020.1.tar.gz", hash = "sha256:3efa13b335a00a8de1d345ae41ec78dd11c9f8807f522d39850f2dd828681540"},
-]
-six = [
-    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
-    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
+telegram-click-aio = [
+    {file = "telegram_click_aio-1.0.0-py3-none-any.whl", hash = "sha256:5ca9ce9144d2dc5df25d909a97a7ca680e9ce3be01712a8a806d5ac22a900b0e"},
+    {file = "telegram_click_aio-1.0.0.tar.gz", hash = "sha256:56cd35791334ab318928218af9a17885552f7de927e633697f7ff0abb690f5bf"},
 ]
 typing = [
     {file = "typing-3.7.4.3-py2-none-any.whl", hash = "sha256:283d868f5071ab9ad873e5e52268d611e851c870a2ba354193026f2dfb29d8b5"},
@@ -723,9 +675,6 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3-py2-none-any.whl", hash = "sha256:dafc7639cde7f1b6e1acc0f457842a83e722ccca8eef5270af2d74792619a89f"},
     {file = "typing_extensions-3.7.4.3-py3-none-any.whl", hash = "sha256:7cb407020f00f7bfc3cb3e7881628838e69d8f3fcab2f64742a5e76b2f841918"},
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
-]
-tzlocal = [
-    {file = "tzlocal-1.5.1.tar.gz", hash = "sha256:4ebeb848845ac898da6519b9b31879cf13b6626f7184c496037b818e238f2c4e"},
 ]
 wrapt = [
     {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,9 +40,7 @@ click = "^7.1"
 emoji = "^1.1"
 Jinja2 = "^2.11"
 prometheus_async = { version = "^19.2", extras = ["aiohttp"] }
-
-# Optional dependencies (extras)
-pendulum = { version = "^1.4", optional = true }
+telegram-click-aio = "^1.0.0"
 
 #[tool.poetry.dev-dependencies]
 #pytest = "^3.0"


### PR DESCRIPTION
#3

This is more of a proof of concept than a final implementation.

Adds an `/alerts` (or `/a`) command to list all currently firing alerts.
Since the API response from alertmanager when retrieving alerts is not the same as when receiving webhook calls from an alert change, I am not sure how to proceed with this. Thoughts welcome.

This is how it looks with the implementation in this PR:
![image](https://user-images.githubusercontent.com/14024504/105642392-b4b19700-5e89-11eb-8a6f-25c0b90dc951.png)
